### PR TITLE
Fix end droping problem

### DIFF
--- a/textsearch/python/textsearch/match.py
+++ b/textsearch/python/textsearch/match.py
@@ -200,11 +200,17 @@ def _break_query(
 
     query_start, target_start = prev_break_point
     query_end = next_query_base
+    target_end = next_target_base
 
-    target_end = target_start + (query_end - query_start)
-    target_end = (
-        target_end if target_end <= next_target_base else next_target_base
-    )
+    # Cancel the following operations to keep the full range of target text
+    # as a resolution to end-text dropping problem
+    # eg. query = "...(long text < breaking thredshold) Hi how are you"
+    # target = "...(long text < breaking thredshold) Hi uh how are you"
+
+    # target_end = target_start + (query_end - query_start)
+    # target_end = (
+    #     target_end if target_end <= next_target_base else next_target_base
+    # )
 
     if query_end - query_start < segment_length // 4:
         if segments:


### PR DESCRIPTION
I found issue #72 can be solved easily by using the full length of target text in matching._break_query. After testing on my audio resources, there was no increase in time consumption and word error rate, and the end dropping issue disappeared.

*end dropping issue was like: the text(ref) contents is less than the contents of the audio segment in manifest output. The text ends before the speech ends.

If there's better way to solve this problem, please let me now.